### PR TITLE
Removed some of nios models, versions and licenses

### DIFF
--- a/main/createUiDefinition.json
+++ b/main/createUiDefinition.json
@@ -41,7 +41,7 @@
             },
             {
               "label": "CP-V805",
-              "value": "CP-V805"
+              "value": "cp-v805"
             },
             {
               "label": "CP-V1400",
@@ -49,7 +49,7 @@
             },
             {
               "label": "CP-V1405",
-              "value": "CP-V1405"
+              "value": "cp-v1405"
             },
             {
               "label": "CP-V2200",
@@ -57,7 +57,7 @@
             },
             {
               "label": "CP-V2205",
-              "value": "CP-V2205"
+              "value": "cp-v2205"
             }
           ]
         },
@@ -284,7 +284,7 @@
               }
             ]
           },
-          "visible": "[equals(basics('niosModel'), 'CP-V805')]"
+          "visible": "[equals(basics('niosModel'), 'cp-v805')]"
         },
         {
           "name": "niosVersion-vnios-cp-v1400",
@@ -328,7 +328,7 @@
               }
             ]
           },
-          "visible": "[equals(basics('niosModel'), 'CP-V1405')]"
+          "visible": "[equals(basics('niosModel'), 'cp-v1405')]"
         },
         {
           "name": "niosVersion-vnios-cp-v2200",
@@ -372,7 +372,7 @@
               }
             ]
           },
-          "visible": "[equals(basics('niosModel'), 'CP-V2205')]"
+          "visible": "[equals(basics('niosModel'), 'cp-v2205')]"
         },
         {
           "name": "vmSize-vnios-te-v820",
@@ -507,7 +507,7 @@
               "Standard_DS11_v2"
             ]
           },
-          "visible": "[equals(basics('niosModel'), 'CP-V805')]",
+          "visible": "[equals(basics('niosModel'), 'cp-v805')]",
           "osPlatform": "Linux"
         },
         {
@@ -541,7 +541,7 @@
               "Standard_DS12_v2"
             ]
           },
-          "visible": "[equals(basics('niosModel'), 'CP-V1405')]",
+          "visible": "[equals(basics('niosModel'), 'cp-v1405')]",
           "osPlatform": "Linux"
         },
         {
@@ -575,7 +575,7 @@
               "Standard_DS13_v2"
             ]
           },
-          "visible": "[equals(basics('niosModel'), 'CP-V2205')]",
+          "visible": "[equals(basics('niosModel'), 'cp-v2205')]",
           "osPlatform": "Linux"
         },
         {
@@ -765,7 +765,7 @@
                   }
                 ]
               },
-              "visible": "[or(equals(basics('niosModel'), 'CP-V805'), equals(basics('niosModel'), 'CP-V1405'), equals(basics('niosModel'), 'CP-V2205'))]"
+              "visible": "[or(equals(basics('niosModel'), 'cp-v805'), equals(basics('niosModel'), 'cp-v1405'), equals(basics('niosModel'), 'cp-v2205'))]"
             }
           ],
           "visible": true

--- a/main/createUiDefinition.json
+++ b/main/createUiDefinition.json
@@ -36,24 +36,12 @@
               "value": "IB-V2225"
             },
             {
-              "label": "CP-V800",
-              "value": "vnios-cp-v800"
-            },
-            {
               "label": "CP-V805",
               "value": "cp-v805"
             },
             {
-              "label": "CP-V1400",
-              "value": "vnios-cp-v1400"
-            },
-            {
               "label": "CP-V1405",
               "value": "cp-v1405"
-            },
-            {
-              "label": "CP-V2200",
-              "value": "vnios-cp-v2200"
             },
             {
               "label": "CP-V2205",
@@ -243,34 +231,6 @@
           "visible": "[equals(basics('niosModel'), 'IB-V2225')]"
         },
         {
-          "name": "niosVersion-vnios-cp-v800",
-          "type": "Microsoft.Common.DropDown",
-          "label": "NIOS version for CP-V800",
-          "defaultValue": "8.3.0",
-          "toolTip": "Select the version of NIOS to load",
-          "constraints": {
-            "allowedValues": [
-              {
-                "label": "8.0.0",
-                "value": "800.343389.3"
-              },
-              {
-                "label": "8.1.0",
-                "value": "810.352813.0"
-              },
-              {
-                "label": "8.2.1",
-                "value": "821.359366.0"
-              },
-              {
-                "label": "8.3.0",
-                "value": "830.371835.0"
-              }
-            ]
-          },
-          "visible": "[equals(basics('niosModel'), 'vnios-cp-v800')]"
-        },
-        {
           "name": "niosVersion-CP-V805",
           "type": "Microsoft.Common.DropDown",
           "label": "NIOS version for CP-V805",
@@ -287,34 +247,6 @@
           "visible": "[equals(basics('niosModel'), 'cp-v805')]"
         },
         {
-          "name": "niosVersion-vnios-cp-v1400",
-          "type": "Microsoft.Common.DropDown",
-          "label": "NIOS version for CP-V1400",
-          "defaultValue": "8.3.0",
-          "toolTip": "Select the version of NIOS to load",
-          "constraints": {
-            "allowedValues": [
-              {
-                "label": "8.0.0",
-                "value": "800.343389.3"
-              },
-              {
-                "label": "8.1.0",
-                "value": "810.352813.0"
-              },
-              {
-                "label": "8.2.1",
-                "value": "821.359366.0"
-              },
-              {
-                "label": "8.3.0",
-                "value": "830.371835.0"
-              }
-            ]
-          },
-          "visible": "[equals(basics('niosModel'), 'vnios-cp-v1400')]"
-        },
-        {
           "name": "niosVersion-CP-V1405",
           "type": "Microsoft.Common.DropDown",
           "label": "NIOS version for CP-V1405",
@@ -329,34 +261,6 @@
             ]
           },
           "visible": "[equals(basics('niosModel'), 'cp-v1405')]"
-        },
-        {
-          "name": "niosVersion-vnios-cp-v2200",
-          "type": "Microsoft.Common.DropDown",
-          "label": "NIOS version for CP-V2200",
-          "defaultValue": "8.3.0",
-          "toolTip": "Select the version of NIOS to load",
-          "constraints": {
-            "allowedValues": [
-              {
-                "label": "8.0.0",
-                "value": "800.343389.3"
-              },
-              {
-                "label": "8.1.0",
-                "value": "810.352813.0"
-              },
-              {
-                "label": "8.2.1",
-                "value": "821.359366.0"
-              },
-              {
-                "label": "8.3.0",
-                "value": "830.371835.0"
-              }
-            ]
-          },
-          "visible": "[equals(basics('niosModel'), 'vnios-cp-v2200')]"
         },
         {
           "name": "niosVersion-CP-V2205",
@@ -477,24 +381,6 @@
           "osPlatform": "Linux"
         },
         {
-          "name": "vmSize-vnios-cp-v800",
-          "type": "Microsoft.Compute.SizeSelector",
-          "label": "Virtual machine size for CP-V800",
-          "toolTip": "Select the size of VM for CP-V800",
-          "recommendedSizes": [
-            "Standard_DS2",
-            "Standard_DS2_v2"
-          ],
-          "constraints": {
-            "allowedSizes": [
-              "Standard_DS2",
-              "Standard_DS2_v2"
-            ]
-          },
-          "visible": "[equals(basics('niosModel'), 'vnios-cp-v800')]",
-          "osPlatform": "Linux"
-        },
-        {
           "name": "vmSize-CP-V805",
           "type": "Microsoft.Compute.SizeSelector",
           "label": "Virtual machine size for CP-V805",
@@ -511,24 +397,6 @@
           "osPlatform": "Linux"
         },
         {
-          "name": "vmSize-vnios-cp-v1400",
-          "type": "Microsoft.Compute.SizeSelector",
-          "label": "Virtual machine size for CP-V1400",
-          "toolTip": "Select the size of VM for CP-V1400",
-          "recommendedSizes": [
-            "Standard_DS3",
-            "Standard_DS3_v2"
-          ],
-          "constraints": {
-            "allowedSizes": [
-              "Standard_DS3",
-              "Standard_DS3_v2"
-            ]
-          },
-          "visible": "[equals(basics('niosModel'), 'vnios-cp-v1400')]",
-          "osPlatform": "Linux"
-        },
-        {
           "name": "vmSize-CP-V1405",
           "type": "Microsoft.Compute.SizeSelector",
           "label": "Virtual machine size for CP-V1405",
@@ -542,24 +410,6 @@
             ]
           },
           "visible": "[equals(basics('niosModel'), 'cp-v1405')]",
-          "osPlatform": "Linux"
-        },
-        {
-          "name": "vmSize-vnios-cp-v2200",
-          "type": "Microsoft.Compute.SizeSelector",
-          "label": "Virtual machine size for CP-V2200",
-          "toolTip": "Select the size of VM for CP-V2200",
-          "recommendedSizes": [
-            "Standard_DS3",
-            "Standard_DS3_v2"
-          ],
-          "constraints": {
-            "allowedSizes": [
-              "Standard_DS3",
-              "Standard_DS3_v2"
-            ]
-          },
-          "visible": "[equals(basics('niosModel'), 'vnios-cp-v2200')]",
           "osPlatform": "Linux"
         },
         {
@@ -708,26 +558,6 @@
               "visible": "[or(equals(basics('niosModel'), 'vnios-te-v820'), equals(basics('niosModel'), 'vnios-te-v1420'), equals(basics('niosModel'), 'vnios-te-v2220'))]"
             },
             {
-              "name": "licenses2",
-              "type": "Microsoft.Common.OptionsGroup",
-              "label": "Install temporary licenses",
-              "defaultValue": "yes",
-              "toolTip": "Select yes to install automatically temporary licenses vNIOS, Grid, DNS, RPZ and Cloud(CP). Validity of license is 60 days. Will add 5 min extra time on the VM Creation",
-              "constraints": {
-                "allowedValues": [
-                  {
-                    "label": "yes",
-                    "value": "CP"
-                  },
-                  {
-                    "label": "no",
-                    "value": "none"
-                  }
-                ]
-              },
-              "visible": "[or(equals(basics('niosModel'), 'vnios-cp-v800'), equals(basics('niosModel'), 'vnios-cp-v1400'), equals(basics('niosModel'), 'vnios-cp-v2200'))]"
-            },
-            {
               "name": "licenses3",
               "type": "Microsoft.Common.OptionsGroup",
               "label": "Install temporary licenses",
@@ -800,9 +630,9 @@
     "outputs": {
       "vmName": "[basics('vmName')]",
       "location": "[location()]",
-      "vmSize": "[coalesce(steps('vmSettings').vmSize-vnios-te-v820,steps('vmSettings').vmSize-vnios-te-v1420,steps('vmSettings').vmSize-vnios-te-v2220,steps('vmSettings').vmSize-vnios-cp-v800,steps('vmSettings').vmSize-CP-V805,steps('vmSettings').vmSize-vnios-cp-v1400,steps('vmSettings').vmSize-CP-V1405,steps('vmSettings').vmSize-vnios-cp-v2200,steps('vmSettings').vmSize-CP-V2205,steps('vmSettings').vmSize-IB-V825,steps('vmSettings').vmSize-IB-V1425,steps('vmSettings').vmSize-IB-V2225)]",
+      "vmSize": "[coalesce(steps('vmSettings').vmSize-vnios-te-v820,steps('vmSettings').vmSize-vnios-te-v1420,steps('vmSettings').vmSize-vnios-te-v2220,steps('vmSettings').vmSize-CP-V805,steps('vmSettings').vmSize-CP-V1405,steps('vmSettings').vmSize-CP-V2205,steps('vmSettings').vmSize-IB-V825,steps('vmSettings').vmSize-IB-V1425,steps('vmSettings').vmSize-IB-V2225)]",
       "niosModel": "[basics('niosModel')]",
-      "niosVersion":  "[coalesce(steps('vmSettings').niosVersion-vnios-te-v820,steps('vmSettings').niosVersion-vnios-te-v1420,steps('vmSettings').niosVersion-vnios-te-v2220,steps('vmSettings').niosVersion-vnios-cp-v800, steps('vmSettings').niosVersion-CP-V805,steps('vmSettings').niosVersion-vnios-cp-v1400, steps('vmSettings').niosVersion-CP-V1405,steps('vmSettings').niosVersion-vnios-cp-v2200,steps('vmSettings').niosVersion-CP-V2205,steps('vmSettings').niosVersion-IB-V825,steps('vmSettings').niosVersion-IB-V1425,steps('vmSettings').niosVersion-IB-V2225)]",
+      "niosVersion":  "[coalesce(steps('vmSettings').niosVersion-vnios-te-v820,steps('vmSettings').niosVersion-vnios-te-v1420,steps('vmSettings').niosVersion-vnios-te-v2220,steps('vmSettings').niosVersion-CP-V805, steps('vmSettings').niosVersion-CP-V1405,steps('vmSettings').niosVersion-CP-V2205,steps('vmSettings').niosVersion-IB-V825,steps('vmSettings').niosVersion-IB-V1425,steps('vmSettings').niosVersion-IB-V2225)]",
       "adminPassword": "[basics('passwordSection').adminPassword]",
 
       "virtualNetworkName": "[steps('vmSettings').niosNetwork.name]",
@@ -834,7 +664,7 @@
       "publicIPExistingRGName": "[steps('vmSettings').dnsAndPublicIP.resourceGroup]",
 
       "availabilitySetNewOrExistingOrNone": "none",
-      "tempLicenseOption": "[coalesce(steps('vmSettings').licenseSection.licenses1, steps('vmSettings').licenseSection.licenses2, steps('vmSettings').licenseSection.licenses3, steps('vmSettings').licenseSection.licenses4)]",
+      "tempLicenseOption": "[coalesce(steps('vmSettings').licenseSection.licenses1,steps('vmSettings').licenseSection.licenses3, steps('vmSettings').licenseSection.licenses4)]",
 
       "customData": "[coalesce(steps('vmSettings').enhancedOptionsSection.customData, '')]"
     }

--- a/main/createUiDefinition.json
+++ b/main/createUiDefinition.json
@@ -12,24 +12,12 @@
         "constraints": {
           "allowedValues": [
             {
-              "label": "TE-V820",
-              "value": "vnios-te-v820"
-            },
-            {
               "label": "TE-V825",
               "value": "IB-V825"
             },
             {
-              "label": "TE-V1420",
-              "value": "vnios-te-v1420"
-            },
-            {
               "label": "TE-V1425",
               "value": "IB-V1425"
-            },
-            {
-              "label": "TE-V2220",
-              "value": "vnios-te-v2220"
             },
             {
               "label": "TE-V2225",
@@ -99,43 +87,15 @@
       },
       "elements": [
         {
-          "name": "niosVersion-vnios-te-v820",
-          "type": "Microsoft.Common.DropDown",
-          "label": "NIOS version for TE-V820",
-          "defaultValue": "8.1.0",
-          "toolTip": "Select the version of NIOS to load",
-          "constraints": {
-            "allowedValues": [
-              {
-                "label": "8.0.0",
-                "value": "800.343389.3"
-              },
-              {
-                "label": "8.1.0",
-                "value": "810.352813.0"
-              }
-            ]
-          },
-          "visible": "[equals(basics('niosModel'), 'vnios-te-v820')]"
-        },
-        {
           "name": "niosVersion-IB-V825",
           "type": "Microsoft.Common.DropDown",
           "label": "NIOS version for TE-V825",
-          "defaultValue": "8.4.2",
+          "defaultValue": "8.4.3",
           "toolTip": "Select the version of NIOS to load",
           "constraints": {
             "allowedValues": [
               {
-                "label": "8.2.1",
-                "value": "821.359366.0"
-              },
-              {
-                "label": "8.3.0",
-                "value": "830.371835.0"
-              },
-              {
-                "label": "8.4.2",
+                "label": "8.4.3",
                 "value": "842.383580.0"
               }
             ]
@@ -143,43 +103,15 @@
           "visible": "[equals(basics('niosModel'), 'IB-V825')]"
         },
         {
-          "name": "niosVersion-vnios-te-v1420",
-          "type": "Microsoft.Common.DropDown",
-          "label": "NIOS version for TE-V1420",
-          "defaultValue": "8.1.0",
-          "toolTip": "Select the version of NIOS to load",
-          "constraints": {
-            "allowedValues": [
-              {
-                "label": "8.0.0",
-                "value": "800.343389.3"
-              },
-              {
-                "label": "8.1.0",
-                "value": "810.352813.0"
-              }
-            ]
-          },
-          "visible": "[equals(basics('niosModel'), 'vnios-te-v1420')]"
-        },
-        {
           "name": "niosVersion-IB-V1425",
           "type": "Microsoft.Common.DropDown",
           "label": "NIOS version for TE-V1425",
-          "defaultValue": "8.4.2",
+          "defaultValue": "8.4.3",
           "toolTip": "Select the version of NIOS to load",
           "constraints": {
             "allowedValues": [
               {
-                "label": "8.2.1",
-                "value": "821.359366.0"
-              },
-              {
-                "label": "8.3.0",
-                "value": "830.371835.0"
-              },
-              {
-                "label": "8.4.2",
+                "label": "8.4.3",
                 "value": "842.383580.0"
               }
             ]
@@ -187,43 +119,15 @@
           "visible": "[equals(basics('niosModel'), 'IB-V1425')]"
         },
         {
-          "name": "niosVersion-vnios-te-v2220",
-          "type": "Microsoft.Common.DropDown",
-          "label": "NIOS version for TE-V2220",
-          "defaultValue": "8.1.0",
-          "toolTip": "Select the version of NIOS to load",
-          "constraints": {
-            "allowedValues": [
-              {
-                "label": "8.0.0",
-                "value": "800.343389.3"
-              },
-              {
-                "label": "8.1.0",
-                "value": "810.352813.0"
-              }
-            ]
-          },
-          "visible": "[equals(basics('niosModel'), 'vnios-te-v2220')]"
-        },
-        {
           "name": "niosVersion-IB-V2225",
           "type": "Microsoft.Common.DropDown",
           "label": "NIOS version for TE-V2225",
-          "defaultValue": "8.4.2",
+          "defaultValue": "8.4.3",
           "toolTip": "Select the version of NIOS to load",
           "constraints": {
             "allowedValues": [
               {
-                "label": "8.2.1",
-                "value": "821.359366.0"
-              },
-              {
-                "label": "8.3.0",
-                "value": "830.371835.0"
-              },
-              {
-                "label": "8.4.2",
+                "label": "8.4.3",
                 "value": "842.383580.0"
               }
             ]
@@ -234,12 +138,12 @@
           "name": "niosVersion-CP-V805",
           "type": "Microsoft.Common.DropDown",
           "label": "NIOS version for CP-V805",
-          "defaultValue": "8.4.2",
+          "defaultValue": "8.4.3",
           "toolTip": "Select the version of NIOS to load",
           "constraints": {
             "allowedValues": [
               {
-                "label": "8.4.2",
+                "label": "8.4.3",
                 "value": "842.383580.0"
               }
             ]
@@ -250,12 +154,12 @@
           "name": "niosVersion-CP-V1405",
           "type": "Microsoft.Common.DropDown",
           "label": "NIOS version for CP-V1405",
-          "defaultValue": "8.4.2",
+          "defaultValue": "8.4.3",
           "toolTip": "Select the version of NIOS to load",
           "constraints": {
             "allowedValues": [
               {
-                "label": "8.4.2",
+                "label": "8.4.3",
                 "value": "842.383580.0"
               }
             ]
@@ -266,35 +170,17 @@
           "name": "niosVersion-CP-V2205",
           "type": "Microsoft.Common.DropDown",
           "label": "NIOS version for CP-V2205",
-          "defaultValue": "8.4.2",
+          "defaultValue": "8.4.3",
           "toolTip": "Select the version of NIOS to load",
           "constraints": {
             "allowedValues": [
               {
-                "label": "8.4.2",
+                "label": "8.4.3",
                 "value": "842.383580.0"
               }
             ]
           },
           "visible": "[equals(basics('niosModel'), 'cp-v2205')]"
-        },
-        {
-          "name": "vmSize-vnios-te-v820",
-          "type": "Microsoft.Compute.SizeSelector",
-          "label": "Virtual machine size for TE-V820",
-          "toolTip": "Select the size of VM for TE-V820",
-          "recommendedSizes": [
-            "Standard_DS2",
-            "Standard_DS2_v2"
-          ],
-          "constraints": {
-            "allowedSizes": [
-              "Standard_DS2",
-              "Standard_DS2_v2"
-            ]
-          },
-          "visible": "[equals(basics('niosModel'), 'vnios-te-v820')]",
-          "osPlatform": "Linux"
         },
         {
           "name": "vmSize-IB-V825",
@@ -313,24 +199,6 @@
           "osPlatform": "Linux"
         },
         {
-          "name": "vmSize-vnios-te-v1420",
-          "type": "Microsoft.Compute.SizeSelector",
-          "label": "Virtual machine size for TE-V1420",
-          "toolTip": "Select the size of VM for TE-V1420",
-          "recommendedSizes": [
-            "Standard_DS3",
-            "Standard_DS3_v2"
-          ],
-          "constraints": {
-            "allowedSizes": [
-              "Standard_DS3",
-              "Standard_DS3_v2"
-            ]
-          },
-          "visible": "[equals(basics('niosModel'), 'vnios-te-v1420')]",
-          "osPlatform": "Linux"
-        },
-        {
           "name": "vmSize-IB-V1425",
           "type": "Microsoft.Compute.SizeSelector",
           "label": "Virtual machine size for TE-V1425",
@@ -344,24 +212,6 @@
             ]
           },
           "visible": "[equals(basics('niosModel'), 'IB-V1425')]",
-          "osPlatform": "Linux"
-        },
-        {
-          "name": "vmSize-vnios-te-v2220",
-          "type": "Microsoft.Compute.SizeSelector",
-          "label": "Virtual machine size for TE-V2220",
-          "toolTip": "Select the size of VM for TE-V2220",
-          "recommendedSizes": [
-            "Standard_DS3",
-            "Standard_DS3_v2"
-          ],
-          "constraints": {
-            "allowedSizes": [
-              "Standard_DS3",
-              "Standard_DS3_v2"
-            ]
-          },
-          "visible": "[equals(basics('niosModel'), 'vnios-te-v2220')]",
           "osPlatform": "Linux"
         },
         {
@@ -538,26 +388,6 @@
           "label": "Licenses",
           "elements": [
             {
-              "name": "licenses1",
-              "type": "Microsoft.Common.OptionsGroup",
-              "label": "Install temporary licenses",
-              "defaultValue": "yes",
-              "toolTip": "Select yes to install automatically temporary licenses vNIOS, Grid, DNS and Cloud(CNA). Validity of license is 60 days. Will add 5 min extra time on the VM Creation",
-              "constraints": {
-                "allowedValues": [
-                  {
-                    "label": "yes",
-                    "value": "TE"
-                  },
-                  {
-                    "label": "no",
-                    "value": "none"
-                  }
-                ]
-              },
-              "visible": "[or(equals(basics('niosModel'), 'vnios-te-v820'), equals(basics('niosModel'), 'vnios-te-v1420'), equals(basics('niosModel'), 'vnios-te-v2220'))]"
-            },
-            {
               "name": "licenses3",
               "type": "Microsoft.Common.OptionsGroup",
               "label": "Install temporary licenses",
@@ -630,9 +460,9 @@
     "outputs": {
       "vmName": "[basics('vmName')]",
       "location": "[location()]",
-      "vmSize": "[coalesce(steps('vmSettings').vmSize-vnios-te-v820,steps('vmSettings').vmSize-vnios-te-v1420,steps('vmSettings').vmSize-vnios-te-v2220,steps('vmSettings').vmSize-CP-V805,steps('vmSettings').vmSize-CP-V1405,steps('vmSettings').vmSize-CP-V2205,steps('vmSettings').vmSize-IB-V825,steps('vmSettings').vmSize-IB-V1425,steps('vmSettings').vmSize-IB-V2225)]",
+      "vmSize": "[coalesce(steps('vmSettings').vmSize-CP-V805,steps('vmSettings').vmSize-CP-V1405,steps('vmSettings').vmSize-CP-V2205,steps('vmSettings').vmSize-IB-V825,steps('vmSettings').vmSize-IB-V1425,steps('vmSettings').vmSize-IB-V2225)]",
       "niosModel": "[basics('niosModel')]",
-      "niosVersion":  "[coalesce(steps('vmSettings').niosVersion-vnios-te-v820,steps('vmSettings').niosVersion-vnios-te-v1420,steps('vmSettings').niosVersion-vnios-te-v2220,steps('vmSettings').niosVersion-CP-V805, steps('vmSettings').niosVersion-CP-V1405,steps('vmSettings').niosVersion-CP-V2205,steps('vmSettings').niosVersion-IB-V825,steps('vmSettings').niosVersion-IB-V1425,steps('vmSettings').niosVersion-IB-V2225)]",
+      "niosVersion":  "[coalesce(steps('vmSettings').niosVersion-CP-V805, steps('vmSettings').niosVersion-CP-V1405,steps('vmSettings').niosVersion-CP-V2205,steps('vmSettings').niosVersion-IB-V825,steps('vmSettings').niosVersion-IB-V1425,steps('vmSettings').niosVersion-IB-V2225)]",
       "adminPassword": "[basics('passwordSection').adminPassword]",
 
       "virtualNetworkName": "[steps('vmSettings').niosNetwork.name]",
@@ -664,7 +494,7 @@
       "publicIPExistingRGName": "[steps('vmSettings').dnsAndPublicIP.resourceGroup]",
 
       "availabilitySetNewOrExistingOrNone": "none",
-      "tempLicenseOption": "[coalesce(steps('vmSettings').licenseSection.licenses1,steps('vmSettings').licenseSection.licenses3, steps('vmSettings').licenseSection.licenses4)]",
+      "tempLicenseOption": "[coalesce(steps('vmSettings').licenseSection.licenses3, steps('vmSettings').licenseSection.licenses4)]",
 
       "customData": "[coalesce(steps('vmSettings').enhancedOptionsSection.customData, '')]"
     }

--- a/main/mainTemplate.json
+++ b/main/mainTemplate.json
@@ -41,7 +41,7 @@
     },
     "niosModel":{
       "type":"string",
-      "defaultValue":"CP-V1405",
+      "defaultValue":"cp-v1405",
       "metadata":{
         "description":"niosModel."
       },
@@ -52,11 +52,11 @@
         "vnios-te-v2220",
         "IB-V2225",
         "vnios-cp-v800",
-        "CP-V805",
+        "cp-v805",
         "vnios-cp-v1400",
-        "CP-V1405",
+        "cp-v1405",
         "vnios-cp-v2200",
-        "CP-V2205"
+        "cp-v2205"
       ]
     },
     "niosVersion":{
@@ -303,7 +303,7 @@
   },
   "variables":{
     "imagePublisher":"infoblox",
-    "imageOffer":"infoblox-CP-V1405",
+    "imageOffer":"infoblox-cp-v1405",
     "imageSKU": "[variables(concat('imageSKUSoT-', variables('imageSKUSoT')))]",
     "imageSKUSoT": "[contains(parameters('niosModel'), 'IB-V')]",
     "imageSKUSoT-true": "vsot",

--- a/main/mainTemplate.json
+++ b/main/mainTemplate.json
@@ -46,16 +46,11 @@
         "description":"niosModel."
       },
       "allowedValues":[
-        "vnios-te-v820",
         "IB-V825",
         "IB-V1425",
-        "vnios-te-v2220",
         "IB-V2225",
-        "vnios-cp-v800",
         "cp-v805",
-        "vnios-cp-v1400",
         "cp-v1405",
-        "vnios-cp-v2200",
         "cp-v2205"
       ]
     },
@@ -67,10 +62,6 @@
       },
       "allowedValues":[
         "latest",
-        "800.343389.3",
-        "810.352813.0",
-        "821.359366.0",
-        "830.371835.0",
         "842.383580.0"
       ]
     },


### PR DESCRIPTION
1) Removed models vnios-cp-v1400, vnios-cp-v2200, vnios-cp-v800, vnios-te-v1420, vnios-te-v2220 and vnios-te-v820 from createUiDefinition.json and mainTemplate.json
2) Removed all the nios versions, Kept 842 value for 843 label and later should replace 842 value from 843 when image is uploaded to AZURe
3) licenses1 and licenses2 are removed from  createUiDefinition.json as they were related to removed nios models