### PR TITLE
NIOS 8.6.0 templates

### DIFF
--- a/main/createUiDefinition.json
+++ b/main/createUiDefinition.json
@@ -91,13 +91,13 @@
           "name": "niosVersion-IB-V825",
           "type": "Microsoft.Common.DropDown",
           "label": "NIOS version for TE-V825",
-          "defaultValue": "8.4.3",
+          "defaultValue": "8.6.0",
           "toolTip": "Select the version of NIOS to load",
           "constraints": {
             "allowedValues": [
               {
-                "label": "8.4.3",
-                "value": "843.383835.0"
+                "label": "8.6.0",
+                "value": "860.412613.0"
               }
             ]
           },
@@ -107,13 +107,13 @@
           "name": "niosVersion-IB-V1425",
           "type": "Microsoft.Common.DropDown",
           "label": "NIOS version for TE-V1425",
-          "defaultValue": "8.4.3",
+          "defaultValue": "8.6.0",
           "toolTip": "Select the version of NIOS to load",
           "constraints": {
             "allowedValues": [
               {
-                "label": "8.4.3",
-                "value": "843.383835.0"
+                "label": "8.6.0",
+                "value": "860.412613.0"
               }
             ]
           },
@@ -123,13 +123,13 @@
           "name": "niosVersion-IB-V2225",
           "type": "Microsoft.Common.DropDown",
           "label": "NIOS version for TE-V2225",
-          "defaultValue": "8.4.3",
+          "defaultValue": "8.6.0",
           "toolTip": "Select the version of NIOS to load",
           "constraints": {
             "allowedValues": [
               {
-                "label": "8.4.3",
-                "value": "843.383835.0"
+                "label": "8.6.0",
+                "value": "860.412613.0"
               }
             ]
           },
@@ -139,13 +139,13 @@
           "name": "niosVersion-CP-V805",
           "type": "Microsoft.Common.DropDown",
           "label": "NIOS version for CP-V805",
-          "defaultValue": "8.4.3",
+          "defaultValue": "8.6.0",
           "toolTip": "Select the version of NIOS to load",
           "constraints": {
             "allowedValues": [
               {
-                "label": "8.4.3",
-                "value": "843.383835.0"
+                "label": "8.6.0",
+                "value": "860.412613.0"
               }
             ]
           },
@@ -155,13 +155,13 @@
           "name": "niosVersion-CP-V1405",
           "type": "Microsoft.Common.DropDown",
           "label": "NIOS version for CP-V1405",
-          "defaultValue": "8.4.3",
+          "defaultValue": "8.6.0",
           "toolTip": "Select the version of NIOS to load",
           "constraints": {
             "allowedValues": [
               {
-                "label": "8.4.3",
-                "value": "843.383835.0"
+                "label": "8.6.0",
+                "value": "860.412613.0"
               }
             ]
           },
@@ -171,13 +171,13 @@
           "name": "niosVersion-CP-V2205",
           "type": "Microsoft.Common.DropDown",
           "label": "NIOS version for CP-V2205",
-          "defaultValue": "8.4.3",
+          "defaultValue": "8.6.0",
           "toolTip": "Select the version of NIOS to load",
           "constraints": {
             "allowedValues": [
               {
-                "label": "8.4.3",
-                "value": "843.383835.0"
+                "label": "8.6.0",
+                "value": "860.412613.0"
               }
             ]
           },

--- a/main/mainTemplate.json
+++ b/main/mainTemplate.json
@@ -62,7 +62,7 @@
       },
       "allowedValues":[
         "latest",
-        "843.383835.0"
+        "860.412613.0"
       ]
     },
     "adminPassword":{
@@ -294,7 +294,7 @@
   },
   "variables":{
     "imagePublisher":"infoblox",
-    "imageOffer":"infoblox-cp-v1405",
+    "imageOffer":"infoblox-vm-appliances-860",
     "imageSKU": "[variables(concat('imageSKUSoT-', variables('imageSKUSoT')))]",
     "imageSKUSoT": "[contains(parameters('niosModel'), 'IB-V')]",
     "imageSKUSoT-true": "vsot",
@@ -349,19 +349,6 @@
     "virtualMachineSetURL":"[concat(parameters('artifactsBaseUrl'),'/vm-availabilityset-', variables('availabilitySetExistingOrNone'),'.json')]"
   },
   "resources":[
-    {
-      "name": "pid-6296147f-669c-41b4-adfa-c20bdaf32742",
-      "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2018-02-01",
-      "properties": {
-        "mode": "Incremental",
-        "template": {
-          "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-          "contentVersion": "1.0.0.0",
-          "resources": []
-        }
-      }
-    },
     {
       "name":"SettingUpStorageAccount",
       "type":"Microsoft.Resources/deployments",


### PR DESCRIPTION
- NIOS version and VM offer changes.
- removal of Customer usage attribution ID from template as it is now automatically assigned by Azure in the offers